### PR TITLE
fix regexp to no include new lines

### DIFF
--- a/internal/html/list.go
+++ b/internal/html/list.go
@@ -54,5 +54,5 @@ func (r *listTransformer) Transform(in string) (string, error) {
 }
 
 func init() {
-	register(&listTransformer{regexp.MustCompile("(?m)^[\\*\\#\\-]{1,3}\\s(.*)")})
+	register(&listTransformer{regexp.MustCompile("(?m)^[\\*\\#\\-]{1,3} (.*)")})
 }

--- a/internal/html/list_test.go
+++ b/internal/html/list_test.go
@@ -15,7 +15,7 @@ func TestBulletList(t *testing.T) {
 `
 	buf, err := Parse(content)
 	assert.NoError(err)
-	assert.Equal("<ul>\n<li>some</li>\n<li>bullet</li>\n<li>points</li>\n</ul>", buf)
+	assert.Equal("<div class=\"source-jira\"><ul>\n<li>some</li>\n<li>bullet</li>\n<li>points</li>\n</ul></div>", buf)
 }
 
 func TestBulletListNested(t *testing.T) {
@@ -29,7 +29,7 @@ func TestBulletListNested(t *testing.T) {
 `
 	buf, err := Parse(content)
 	assert.NoError(err)
-	assert.Equal("<ul>\n<li>some</li>\n<li>bullet</li>\n<ul>\n<li>indented</li>\n<li>bullets</li>\n</ul>\n<li>points</li>\n</ul>", buf)
+	assert.Equal("<div class=\"source-jira\"><ul>\n<li>some</li>\n<li>bullet</li>\n<ul>\n<li>indented</li>\n<li>bullets</li>\n</ul>\n<li>points</li>\n</ul></div>", buf)
 }
 
 func TestNumberedList(t *testing.T) {
@@ -40,7 +40,7 @@ func TestNumberedList(t *testing.T) {
 `
 	buf, err := Parse(content)
 	assert.NoError(err)
-	assert.Equal("<ol>\n<li>a</li>\n<li>numbered</li>\n</ol>", buf)
+	assert.Equal("<div class=\"source-jira\"><ol>\n<li>a</li>\n<li>numbered</li>\n</ol></div>", buf)
 }
 
 func TestMixedList(t *testing.T) {
@@ -55,7 +55,7 @@ func TestMixedList(t *testing.T) {
 `
 	buf, err := Parse(content)
 	assert.NoError(err)
-	assert.Equal("<ol>\n<li>a</li>\n<li>numbered</li>\n<ul>\n<li>with</li>\n<li>nested</li>\n<li>bullet</li>\n</ul>\n<li>list</li>\n</ol>", buf)
+	assert.Equal("<div class=\"source-jira\"><ol>\n<li>a</li>\n<li>numbered</li>\n<ul>\n<li>with</li>\n<li>nested</li>\n<li>bullet</li>\n</ul>\n<li>list</li>\n</ol></div>", buf)
 }
 
 func TestMixedList2(t *testing.T) {
@@ -70,5 +70,16 @@ func TestMixedList2(t *testing.T) {
 `
 	buf, err := Parse(content)
 	assert.NoError(err)
-	assert.Equal("<ul>\n<li>a</li>\n<li>bulleted</li>\n<ol>\n<li>with</li>\n<li>nested</li>\n<li>numbered</li>\n</ol>\n<li>list</li>\n</ul>", buf)
+	assert.Equal("<div class=\"source-jira\"><ul>\n<li>a</li>\n<li>bulleted</li>\n<ol>\n<li>with</li>\n<li>nested</li>\n<li>numbered</li>\n</ol>\n<li>list</li>\n</ul></div>", buf)
+}
+
+const listtext = `
+*
+`
+
+func TestMocklist(t *testing.T) {
+	assert := assert.New(t)
+	buf, err := Parse(listtext)
+	assert.NoError(err)
+	assert.Equal("<div class=\"source-jira\">\n*\n</div>", buf)
 }


### PR DESCRIPTION
A newline after an asterisk was matching the pattern